### PR TITLE
Comment out an open tag without a closing tag

### DIFF
--- a/docs/assets/css/theme.css
+++ b/docs/assets/css/theme.css
@@ -517,7 +517,7 @@ body .docsify-pagination-container {
 }
 
 /* Dark mode colours for use with Simple light + dark theme (uncomment to use) */
-@media (prefers-color-scheme: dark) {
+/* @media (prefers-color-scheme: dark) { */
 /*
   :root {
     --link-color: #1BA1EE!important;


### PR DESCRIPTION
A media tag that was left unclosed. The close tag was commented out but the open tag and media was still there.

md css isn't being loaded on some devices, maybe this could be a fix