### PR TITLE
Fixed broken link to execution-spec-tests

### DIFF
--- a/docs/eps/week1.md
+++ b/docs/eps/week1.md
@@ -74,7 +74,7 @@ Tests are generated based on specifications and create various scenarios. Some a
 > Here is a short list of repositories dedicated to testing: 
 > - https://github.com/ethereum/tests
 > - https://github.com/ethereum/retesteth
-> - https://github.cosm/ethereum/execution-spec-tests
+> - https://github.com/ethereum/execution-spec-tests
 > - https://github.com/ethereum/hive
 > - https://github.com/kurtosis-tech/kurtosis
 > - https://github.com/MariusVanDerWijden/FuzzyVM


### PR DESCRIPTION
Fixed a minor typo in the link to execution-spec-tests( it had github.cosm in it)
