### PR TITLE
Use OS default color scheme

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -23,10 +23,10 @@
   <meta property="twitter:description" content="EPF Study Group Wiki">
   <meta property="twitter:image" content="https://raw.githubusercontent.com/eth-protocol-fellows/protocol-studies/wiki-pages/docs/images/epfsg_hero.jpg">
 
-  <!-- Themeable Simple theme dark (use either this on the one below) -->
+  <!-- Themeable Simple theme dark (use either this or the one below) -->
   <!-- <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css">  -->
 
-  <!-- Themeable Simple based on OS default (use either this on the one above) -->
+  <!-- Themeable Simple based on OS default (use either this or the one above) -->
   <link rel="stylesheet" media="(prefers-color-scheme: light)"
     href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple.css">
   <link rel="stylesheet" media="(prefers-color-scheme: dark)"

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,14 +23,14 @@
   <meta property="twitter:description" content="EPF Study Group Wiki">
   <meta property="twitter:image" content="https://raw.githubusercontent.com/eth-protocol-fellows/protocol-studies/wiki-pages/docs/images/epfsg_hero.jpg">
 
-  <!-- Themeable Simple theme dark -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css"> 
+  <!-- Themeable Simple theme dark (use either this on the one below) -->
+  <!-- <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css">  -->
 
-  <!-- Themeable Simple light + dark theme (uncomment to use, and comment out the above loading of Simple theme) -->
-  <!-- <link rel="stylesheet" media="(prefers-color-scheme: light)"
-    href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple.css"> -->
-  <!-- <link rel="stylesheet" media="(prefers-color-scheme: dark)"
-    href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css"> -->
+  <!-- Themeable Simple based on OS default (use either this on the one above) -->
+  <link rel="stylesheet" media="(prefers-color-scheme: light)"
+    href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple.css">
+  <link rel="stylesheet" media="(prefers-color-scheme: dark)"
+    href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css">
 
   <link rel="stylesheet" href="assets/css/theme.css">
   <link rel="stylesheet" href="assets/css/custom.css">


### PR DESCRIPTION
Currently the wiki forces you to use dark mode although the standard on most websites is to default to light mode or OS default, with sometimes the ability to switch between the two with a button.

I suggest we use the OS default color scheme, and maybe later we can add a switch button if it makes sense.