### PR TITLE
✨ KaTex support

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -453,6 +453,13 @@
 </script>
 <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
 
+<!-- KaTex -->
+<script src="//cdn.jsdelivr.net/npm/katex@latest/dist/katex.min.js"></script>
+<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/katex@latest/dist/katex.min.css" />
+<script src="//cdn.jsdelivr.net/npm/marked@4"></script>
+<!--docsify-katex -->
+<script src="//cdn.jsdelivr.net/npm/docsify-katex@latest/dist/docsify-katex.js"></script>
+
 </script>
 
 </body>


### PR DESCRIPTION
Closes #36.

The script is loaded towards the end of the file so as to not block DOM rendering.