### PR TITLE
🐞 fix(Spell check): Handle files with spaces

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -79,7 +79,7 @@ jobs:
               - Use backticks to quote code variables so as to not bloat the \`wordlist\`.
             `;
 
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -29,6 +29,9 @@ jobs:
         id: find_typos
         run: |
           echo "Checking for typos..."
+          # https://unix.stackexchange.com/a/9500
+          IFS=$'\n'
+          set -f
           for file in $(find . -name "*.md" ); do
             output="$(aspell --lang=en_US --mode=markdown --home-dir=. --personal=wordlist.txt --ignore-case=true --camel-case list <$file)"
             echo "$output"

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -12,6 +12,7 @@ ary
 ASE
 Assche
 Assertoor
+assignees
 autoplay
 Bankless
 Barnabe


### PR DESCRIPTION
- [x] Address a breaking change from github-scripts@v7
- [x] Fix an [issue with spell check when markdown files have spaces](https://unix.stackexchange.com/questions/9496/looping-through-files-with-spaces-in-the-names)
- [x] Add "assignees" to wordlist
<!-- 
ℹ️ Checking for typos locally
1. Install [aspell](https://www.gnu.org/software/aspell/) for your platform.
2. Navigate to the project root and run:
```
 for f in **/*.md ; do echo $f ; aspell --lang=en_US --mode=markdown --home-dir=. --personal=wordlist.txt --ignore-case=true --camel-case list  < $f | sort | uniq -c ; done
```

ℹ️ Fixing typos
1. Fix typos: Open the relevant files and fix any identified typos.
2. Update wordlist: If a flagged word is actually a project-specific term add it to `wordlist.txt` in the project root.
   Each word should be listed on a separate line.
 * 🚧 Remember:
    * When adding new words it must NOT have any spaces or special characters within or around it.
    * \`wordlist\` is NOT case sensitive.
    * Use backticks to quote code variables so as to not bloat the \`wordlist\`.
-->
