### PR TITLE
Potuz's correction on PTC and proposer boost and current specs section

### DIFF
--- a/docs/wiki/research/PBS/ePBS.md
+++ b/docs/wiki/research/PBS/ePBS.md
@@ -283,7 +283,42 @@ The Payload-Timeliness Committee (PTC) proposal is a design for enshrining PBS (
 
 #### High-Level Overview
 
-![Payload-Timeliness Committee Flow](/docs/wiki/research/img/scaling/PTC-Flow-ePBS.png)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    rect rgb(240, 237, 225)
+    participant V as Validator (Proposer)
+    participant C as Attesting Committee
+    participant B as Builder
+    participant PTC as Payload-Timeliness Committee
+    participant N1 as Next Proposer (Slot N+1)
+
+    rect rgb(255, 190, 152)
+    Note over V: Slot N begins
+    V->>V: Proposes CL block <br>with builder bid at t=t0
+    Note over V: Block contains no ExecutionPayload
+    end
+    rect rgb(219,188,157)
+    Note over C: Attestation deadline at t=t1
+    C->>C: Use fork-choice to determine chain head
+    C->>V: Attestation
+    end
+    rect rgb(212,202,205)
+    Note over B: At t=t2 Broadcast of <br>Aggregate Attestations
+    C->>C: Begin broadcasting <br>aggregate attestations
+    B-->>V: Publishes execution payload <br>if no equivocation seen
+    end
+    rect rgb(177,176,159)
+    Note over PTC: At t=t3 Cast vote for <br>payload timeliness
+    PTC->>PTC: Votes on payload <br>release timeliness
+    end
+    rect rgb(203, 134, 143)
+    Note over N1: At t=t4 Propagation <br>of next block
+    N1->>N1: Publishes block based on <br>PT votes and attestations
+    end
+    end
+```
 
 _Figure – Payload-Timeliness Committee Flow._
 
@@ -410,7 +445,34 @@ The implementation of PEPC in Ethereum involves several trade-offs, reflecting a
 #### How would PEPC work?
 
 
-![PEPC Workflow](/docs/wiki/research/img/scaling/PEPC-workflow.png)
+```mermaid
+sequenceDiagram
+    participant V as Validator (Proposer)
+    participant B as Builders
+    participant P as Protocol
+    participant N as Network Validators
+
+    V->>V: Define Proposer Commitments (PCs)
+    rect rgb(240, 237, 225)
+
+    V->>P: Generate Commit-Block with PCs & Payload Template
+    loop Builder Submissions
+        B->>V: Submit Blocks/Parts fulfilling PCs
+    end
+    end
+
+    rect rgb(177,176,159)
+    V->>P: Verify Submissions against PCs
+    alt Submission satisfies PCs
+        V->>V: Incorporate Submission into Block
+        V->>N: Publish Finalized Block
+        N->>N: Validate Block (Consensus & PCs)
+        N->>P: Include Block in Blockchain
+    else Submission does not satisfy PCs
+        V->>V: Reject Submission
+    end
+    end
+```
 
 _Figure – PEPC flow._
 

--- a/docs/wiki/research/PBS/ePBS.md
+++ b/docs/wiki/research/PBS/ePBS.md
@@ -850,8 +850,23 @@ The processing of execution payloads in the ePBS system includes several critica
 - **Special Case Handling:** Manages unique scenarios such as transactions enabled by [EIP-3074](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3074.md).
 
 
-
 #### Payload Attestation's Timeline
+
+**Gossip** Payload attestations are broadcasted by PTC members using `PAYLOAD_ATTESTATION_MESSAGE` objects with stringent checks before propagation:
+- **Current Slot Verification:** Only attestations for the current slot are gossiped.
+- **Payload Status Validation:** Attestations must have a valid payload status to be gossiped.
+- **Single Attestation Per Member:** Only one attestation per PTC member is shared.
+- **Beacon Block Root Presence:** Attestations are linked to slots with a known beacon block root.
+- **PTC Membership Check:** Validators must be confirmed members of the PTC.
+- **Signature Verification:** Attestations must have a valid signature.
+
+**Forkchoice Handler** Upon passing gossip validation, payload attestations are processed in the forkchoice through the `on_payload_attestation_message` handler, which includes:
+- **Beacon Block Validation:** Confirms the associated beacon block is in the forkchoice store.
+- **PTC Slot Validation:** Verifies the attester is in the PTC for the specified slot.
+- **Slot Matching:** Checks that the beacon block corresponds to the attestation slot.
+- **Current Slot and Signature Checks (if not from block):** For direct broadcasts, validates the slot is current and verifies the signature.
+- **PTC Vote Update:** Updates the PTC vote tracked in the forkchoice for the given block root.
+
 
 
 #### Beacon Block's Timeline

--- a/docs/wiki/research/PBS/ePBS.md
+++ b/docs/wiki/research/PBS/ePBS.md
@@ -511,7 +511,7 @@ In a broader Ethereum ecosystem context, PEPC and Eigenlayer could be seen as co
 
 ## ePBS Specifications
 
-The current ePBS specification[^12][^13] addresses a critical issue in Ethereum's current implementation of PBS. Traditionally, both proposers and builders have had to rely on intermediaries through MEV-Boost, which introduces trust and censorship concerns as outlined above. The ePBS framework modifies this dynamic by changing the necessity of intermediaries ("must") to an option ("may"), allowing for a more trustless interaction within the Ethereum ecosystem. It incorporates EIP 7251 and EIP 7002, which are integral to its implementation. 
+The current ePBS specification[^12][^13] addresses a critical issue in Ethereum's current implementation of PBS. Traditionally, both proposers and builders have had to rely on intermediaries through MEV-Boost, which introduces trust and censorship concerns as outlined above. The ePBS framework modifies this dynamic by changing the necessity of intermediaries ("must") to an option ("may"), allowing for a more trustless interaction within the Ethereum ecosystem. It incorporates [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) and [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002), which are integral to its implementation. 
 
 EIP-7251 aims to increase the maximum effective balance (Max EB) for Ethereum validators to 2048 ETH while keeping a minimum stake of 32 ETH, reducing the total number of validators without compromising security. EIP-7002 introduces a mechanism allowing validators to trigger exits from the beacon chain using their execution layer (0x01) withdrawal credentials, enhancing flexibility and security for staking operations.
 
@@ -523,14 +523,17 @@ EIP-7251 aims to increase the maximum effective balance (Max EB) for Ethereum va
 
 **Minimal Changes for Compatibility**: The design implements the least number of changes necessary to maintain compatibility with current consensus and execution client operations. It adheres to the existing 12-second slot time, ensuring continuity and stability in the network's operation.
 
-**Censorship Resistance**: It enhances censorship resistance by incorporating forward forced inclusion lists as per EIP-7547, ensuring that certain transactions must be included, which helps in maintaining network integrity.
+**Censorship Resistance**: It enhances censorship resistance by incorporating forward forced inclusion lists as per [EIP-7547](https://eips.ethereum.org/EIPS/eip-7547), ensuring that certain transactions must be included, which helps in maintaining network integrity.
 
 **Layer Enhancements**: The changes are primarily in the consensus layer (CL), with minimal adjustments required on the Execution Layer (EL), mainly related to the handling of inclusion lists.
 
 **Safety Guarantees**:
-    - **Proposer Safety**: It ensures that proposers are protected against 1-slot reorganization attacks by colluding proposers and builders, even those controlling network topology with up to 20% of the stake.
-    - **Builder Safety**: Guarantees are in place for builders against collusion and manipulation by consecutive proposers, including measures to ensure the safety of both withheld and revealed payloads.
-    - **Unbundling Guarantees**: Builders are protected under all attack scenarios, ensuring integrity in transaction handling and execution.
+
+- **Proposer Safety**: It ensures that proposers are protected against 1-slot reorganization attacks by colluding proposers and builders, even those controlling network topology with up to 20% of the stake.
+
+- **Builder Safety**: Guarantees are in place for builders against collusion and manipulation by consecutive proposers, including measures to ensure the safety of both withheld and revealed payloads.
+
+- **Unbundling Guarantees**: Builders are protected under all attack scenarios, ensuring integrity in transaction handling and execution.
 
 **Self-Building for Validators**: Validators retain the capability to self-build their payloads, which is crucial for maintaining independence and flexibility.
 
@@ -540,7 +543,9 @@ EIP-7251 aims to increase the maximum effective balance (Max EB) for Ethereum va
 **Implementation Details:**
 
 The ePBS specification introduces specific roles and responsibilities:
+
 - **Builders**: Validators that submit bids for payload commitments.
+
 - **PTC (Payload Timeliness Committee)**: A new committee that verifies the timeliness and validity of payloads.
 
 During each slot, proposers collect bids, and upon selecting a bid, they submit their blocks with a signed commitment from the builder. Validators then adjust financial credits between builders and proposers based on these commitments. Builders later reveal their execution payloads, fulfilling their obligations. The slot outcomes can vary—missed, empty, or full—based on the production and revelation of the blocks, with the PTC playing a critical role in determining the nature of the slot's conclusion.

--- a/docs/wiki/research/PBS/ePBS.md
+++ b/docs/wiki/research/PBS/ePBS.md
@@ -806,6 +806,29 @@ Explanation of the new slot anatomy flow based on the ePBS specs:
 
 #### Inclusion List Timeline
 
+- **Gossip Layer Checks**:
+  - Inclusion lists are verified for timing, ensuring relevance to the current or next slot.
+  - Each proposer-slot pair is restricted to broadcasting one inclusion list on the network, although proposers may send different lists to different peers.
+  - The number of transactions must match the summary count and not exceed the set maximum in `MAX_TRANSACTIONS_PER_INCLUSION_LIST`.
+  - Inclusion list signatures are validated against the proposer's key, confirming their scheduled slot.
+
+- **Risks and Mitigations**:
+  - Broadcasting an inclusion list for the upcoming slot before a head change may lead to availability issues, although the list is still considered available.
+
+- **on_inclusion_list Handler**:
+  - Serves as a bridge to execution engine API calls, assuming the corresponding beacon block is processed.
+  - If a beacon block's parent was empty, any new inclusion list is automatically ignored to prevent backlog.
+
+- **Beacon State Tracking**:
+  - Tracks proposer and slot for the most recent and previous IL to manage fulfillment and update upon new valid blocks.
+
+- **EL Validation**:
+  - Checks that transactions `inclusion_list.transactions` are valid and includable using the current state.
+  - Ensures summary `inclusion_list.signed_summary.message.summary` accurately lists "from" addresses for the included transactions.
+  - Verifies that the total gas limit of transactions does not exceed the maximum allowed `MAX_GAS_PER_INCLUSION_LIST`.
+  - Ensures accounts listed have sufficient funds to cover the maximum potential gas fees `(base_fee_per_gas + base_fee_per_gas / BASE_FEE_MAX_CHANGE_DENOMINATOR) * gas_limit`.
+
+
 
 #### Execution Payload's Timeline
 
@@ -816,7 +839,7 @@ Explanation of the new slot anatomy flow based on the ePBS specs:
 #### Beacon Block's Timeline
 
 
-### Validator and Builder Specific Functions
+#### Validator and Builder Specific Functions
 
 
 #### Honest Validator Behavior

--- a/docs/wiki/research/PBS/ePBS.md
+++ b/docs/wiki/research/PBS/ePBS.md
@@ -899,11 +899,43 @@ The processing of execution payloads in the ePBS system includes several critica
   - **Doubling the Proposer Penalty**: The rationale for doubling the penalty for the proposer is to ensure that there is no scenario where both a penalty and a reward would cancel each other out, thus maintaining a deterrent against the inclusion of conflicting attestations.
 
 
-#### Validator and Builder Specific Functions
-
-
 #### Honest Validator Behavior
+The roles and behaviors of validators are refined, especially for proposers and PTC members, due to the introduction of new mechanics such as fork choice considerations, execution payload validation, and timing of IL. 
 
+**Proposer Responsibilities**
+- **Execution Payload and Inclusion List Preparation**:
+  - Prior to their designated slot, proposers need to select a `SignedExecutionPayloadHeader` from builders and request or construct an `InclusionList`.
+  - These activities can be conducted before the slot begins to ensure readiness and efficiency.
+- **Broadcast Timing**:
+  - Proposers are incentivized to broadcast their IL early to increase the likelihood of their blocks being attested to, thus securing their block's position in the chain.
+
+- **Builder Interaction**:
+  - Validators can act as their own builders (self-building) or may engage with external builders. Direct interactions with builders (off-protocol methods) are encouraged as they may yield the most competitive bids in real-time.
+
+- **Strategic Considerations**:
+  - Due to potential MEV opportunities, proposers might strategically delay choosing or requesting a builder’s bid until the last feasible moment for block broadcasting. This tactic is to MEV from the available transaction pool.
+
+**Head Determination for Proposers**
+- **Basic Principle**: At the start of slot `N`, proposers must determine the head of the chain to propose a new block effectively. This involves evaluating various scenarios like skipped slots, missing payloads, and late payloads, and making a decision based on the most recent valid block data.
+
+**PTC Member Duties**
+- **Payload Timeliness Attestations**:
+  - PTC members are tasked to verify the timeliness of the execution payload for the current slot and cast a `payload_attestation` based on their observations:
+    - `PAYLOAD_PRESENT`: If both a valid consensus block for the current slot and the corresponding execution payload are observed.
+    - `PAYLOAD_WITHHELD`: If a valid consensus block for the current slot is seen along with a `payload_withheld = true` message from the builder.
+    - `PAYLOAD_ABSENT`: If a valid consensus block is seen without the corresponding execution payload.
+    - No attestation is made if no consensus block for the current slot is observed.
+
+- **Attestation Conditions**:
+  - PTC members only import the first consensus block they observe and base their actions on it, ensuring a single, coherent response per slot.
+
+**Constructing Payload Attestations**
+- **Operational Window**:
+  - PTC members prepare to attest approximately 9 seconds into the slot, evaluating whether the execution payloads are timely and accurately synced with the consensus blocks.
+  - This includes assessing whether payloads are withheld correctly and ensuring that their attestation reflects the actual status of payload availability or absence.
+
+**Validator Considerations**
+- Validators must adeptly handle their roles, whether as proposers, PTC members, or general attestors, navigating the intricacies of new ePBS mechanics to maintain network integrity and security. This involves strategic decision-making, timely actions, and adherence to protocol to optimize their influence and rewards within the network.
 
 #### Honest Builder Behavior
 

--- a/docs/wiki/research/PBS/ePBS.md
+++ b/docs/wiki/research/PBS/ePBS.md
@@ -869,7 +869,6 @@ The processing of execution payloads in the ePBS system includes several critica
 
 
 #### Beacon Block's Timeline
-Here's a condensed summary of the key points regarding the beacon block's timeline in ePBS:
 
 **Gossip**
 - **Initial Validation**: `SignedBeaconBlock` enters through gossip or RPC, with critical validations focusing on the legitimacy of the parent beacon block.

--- a/docs/wiki/research/PBS/ePBS.md
+++ b/docs/wiki/research/PBS/ePBS.md
@@ -976,7 +976,28 @@ class SignedBidRequest(container):
 
 #### Forkchoice Considerations
 
+The introduction of the ePBS fork brings sophisticated changes to the forkchoice rules, specifically targeting builder and proposer safety. These changes are designed to accommodate network delays and strategic behaviors like payload withholding.
 
+**Key Concepts in ePBS Forkchoice:**
+
+- **(Block, Slot) Voting:**
+  - This mechanism ensures that if a block arrives late, validators will support the last timely block instead of the late one.
+  - Consistently, late blocks accumulate less weight as validators continue to support earlier, timely blocks.
+- **Payload Status Handling:**
+  - The status of payloads (missing, empty, full) influences validators' support for chains.
+  - Votes support chains that are consistent with the PTC decisions on payload status, ensuring that payloads are either included or excluded based on timely availability.
+- **Inclusion List Availability:**
+  - The presence and validation of IL are crucial. Validators may base their head determinations on the latest block with a fully validated IL.
+  - This consideration ensures that blocks built on properly included transactions are favored, enhancing the chain integrity.
+- **Security Analysis of Payload Boosts:**
+  - Builder's reveal boost (RB) and withholding boost (WB) are introduced to reward or protect builders based on their actions in revealing or withholding payloads.
+  - These boosts significantly influence the forkchoice by altering the weight calculations, potentially leading to reorganizations or stabilization of the chain based on payload availability and integrity.
+
+**Practical Examples:**
+- **Happy cases** show normal operation where all blocks and payloads arrive on time and receive full support.
+- **Late blocks and payloads** illustrate scenarios where validators shift their support to earlier blocks, affecting the weight distribution across potential chain forks.
+- **Payload status scenarios** demonstrate how votes can either support or exclude certain blocks based on payload availability, aligning with PTC votes.
+- **Inclusion list considerations** highlight the impact of these lists on determining the canonical head, especially in cases of missing or late inclusion data.
 
 
 

--- a/docs/wiki/research/PBS/ePBS.md
+++ b/docs/wiki/research/PBS/ePBS.md
@@ -1070,7 +1070,7 @@ Given the complex landscape and the potential for significant shifts in Ethereum
 
 
 
-## [References]
+## References
 [^1]: https://barnabe.substack.com/p/pbs
 [^2]: https://www.youtube.com/watch?v=Ub8V7lILb_Q
 [^3]: https://www.youtube.com/watch?v=mEbK9AX7X7o

--- a/docs/wiki/research/PBS/ePBS.md
+++ b/docs/wiki/research/PBS/ePBS.md
@@ -939,6 +939,37 @@ The roles and behaviors of validators are refined, especially for proposers and 
 
 #### Honest Builder Behavior
 
+**Preparing Multiple Payloads**
+- **Adaptability**: Builders are expected to prepare different payloads for various potential parent heads. This preparation allows them to adapt to changes in the fork choice at the last moment.
+- **Multiple Bids**: Builders can submit multiple bids ahead of their intended slot, increasing their chances of selection by proposers.
+
+**Bid Submission Strategy**
+- **Broadcasting Bids**: Builders can submit bids via off-protocol services directly to proposers. This strategy allows builders to continually update and refine their bids without exposing them to the entire network, which could potentially lead to the inclusion of suboptimal payloads.
+- **First Seen Message Rule**: Validators will only gossip the first valid seen message for a particular combination of (builder, slot), which encourages builders to submit their best possible bids early in the process.
+
+**Direct Bid Requests**
+- **Enhanced API Specification**: Introducing direct bid requests through a `SignedBidRequest` mechanism would allow validators to request execution headers directly from builders. This minor modification to the builder API could utilize existing client code and enhance direct interactions between validators and builders.
+
+```python
+class BidRequest(container):
+    slot: Slot
+    proposer_index: Validator_index
+    parent_hash: Hash32
+    parent_block_root: Root
+
+class SignedBidRequest(container):
+    message: BidRequest
+    signature: BLSSignature
+```
+
+- **Cryptographic Binding**: The direct request mechanism can be designed to cryptographically bind the request to the validator, preventing builders from adjusting their bids based on what others are offering, thereby reducing the risk of collusion and cartelization among builders.
+
+**Gossip as Fallback**
+- **Fallback Mechanism**: Despite the advantages of direct bid requests, maintaining a global topic for bid gossip provides a crucial fallback. This system supports validators running on lower-end hardware or those who prefer community-driven builders, ensuring they have access to competitive bids.
+- **Anti-Censorship and Anti-Cartel Measures**: By setting a public minimum bid through community-driven builders, the system forces centralized builders to outbid these public offers if they wish to censor certain transactions. This feature serves as a baseline for competition and transparency in bid submission.
+- **Spam Protection**: The global topic can be protected against spam by only allowing the highest value bid received for a given parent block hash to be gossiped, and restricting to one message per builder per slot.
+
+
 
 #### Security analysis of proposer and builder interactions
 

--- a/docs/wiki/research/PBS/ePBS.md
+++ b/docs/wiki/research/PBS/ePBS.md
@@ -6,7 +6,7 @@ Enshrined Proposer-Builder Separation (ePBS) refers to integrating the PBS mecha
 
 ## What is PBS
 
-Proposer-Builder Separation (PBS) is a design philosophy[^1] and mechanism in within the context of Ethereum, that aims to decouple the roles of proposing blocks (proposers) and constructing the content of those blocks (builders). This separation addresses various challenges and inefficiencies associated with block production, and in the context of maximizing extractable value (MEV). This entry assumes reader has knowledge of [MEV](/wiki/research/PBS/mev.md), [PBS](/wiki/research/PBS/pbs.md), and [MEV-Boost](/wiki/research/PBS/mev-boost.md)
+Proposer-Builder Separation (PBS) is a design philosophy[^1] and mechanism within the context of Ethereum, that aims to decouple the roles of proposing blocks (proposers) and constructing the content of those blocks (builders). This separation addresses various challenges and inefficiencies associated with block production, and in the context of maximizing extractable value (MEV). This entry assumes reader has some knowledge of [MEV](/wiki/research/PBS/mev.md), [PBS](/wiki/research/PBS/pbs.md), and [MEV-Boost](/wiki/research/PBS/mev-boost.md)
 
 ## Overview of ePBS
 
@@ -24,8 +24,7 @@ In the ePBS framework:
 
 ### Transition from mev-boost to ePBS
 
-The transition from MEV-Boost to ePBS represents a pivotal evolution in Ethereum's approach to handling MEV and improving the network's efficiency and fairness. Dependency on an external, third party software can be dangerous and lead to network incidents even if clients themselves behave correctly. 
-In the next section, we will cover the details on why ePBS is needed and what will the ecosystem gain from this in-protocol approach to PBS.
+The transition from MEV-Boost to ePBS represents a pivotal evolution in Ethereum's approach to handling MEV and improving the network's efficiency and fairness. Dependency on an external, third party software can be dangerous and lead to network incidents even if clients themselves behave correctly. In the next section, we will cover the details on why ePBS is needed and what will the ecosystem gain from this in-protocol approach to PBS.
 
 ## The Case for ePBS
 
@@ -57,7 +56,7 @@ The transition to ePBS from the current MEV-Boost system is motivated by several
 
 - **Financial Model**: The financial sustainability of relays is also a concern. If the costs of running relays exceed the revenue generated from their operation, it could lead to a reduction in the number of relays, increasing centralization risks and affecting the competitive marketplace for block space.
 
-The transition towards ePBS involves critical economic and security considerations, especially in the context of Miner Extractable Value (MEV) and proposals like MEV burn. These considerations shape the debate around ePBS, highlighting its potential impact on the Ethereum ecosystem. Here's an exploration of these aspects:
+The transition towards ePBS involves critical economic and security considerations, especially in the context of MEV and proposals like MEV burn. These considerations shape the debate around ePBS, highlighting its potential impact on the Ethereum ecosystem. Here's an exploration of these aspects:
 
 ### Economic Considerations
 
@@ -89,7 +88,7 @@ The transition to ePBS from the current MEV-Boost system is driven by a combinat
 
 ## Counterarguments to ePBS
 
-The discussion around the enshrinement of PBS (ePBS) within Ethereum's protocol has stirred significant debate, with various counterarguments presented by its critics. Proponents of ePBS, however, offer robust responses to these concerns, advocating for its necessity and integration into Ethereum's roadmap. Additionally, the discourse explores alternative methods for addressing miner extractable value (MEV), weighing their sufficiency against the proposed ePBS system[^3].
+The discussion around the enshrinement of PBS (ePBS) within Ethereum's protocol has stirred significant debate, with various counterarguments presented by its critics. Proponents of ePBS, however, offer robust responses to these concerns, advocating for its necessity and integration into Ethereum's roadmap. Additionally, the discourse explores alternative methods for addressing MEV, weighing their sufficiency against the proposed ePBS system[^3].
 
 ### Primary Counterarguments Against ePBS
 
@@ -223,7 +222,7 @@ Determining the minimum viable ePBS involves a delicate balance of these propert
 
 ### The Two-Block HeadLock (TBHL) proposal
 
-The Two-Block HeadLock (TBHL) design represents an innovative approach to proposer-builder separation (PBS) within the Ethereum protocol, aiming to address both the operational and strategic issues posed by (MEV)[https://ethresear.ch/t/why-enshrine-proposer-builder-separation-a-viable-path-to-epbs/]. This design is a nuanced iteration of previous proposals, integrating elements of Vitalik Buterin's two-slot design and enhancing it with a headlock mechanism to safeguard builders from proposer equivocations. Here, we delve into the key components of TBHL and its operational mechanics, drawing on the detailed explanation provided[^4].
+The Two-Block HeadLock (TBHL) design represents an innovative approach to proposer-builder separation (PBS) within the Ethereum protocol, aiming to address both the operational and [strategic issues posed by MEV](https://ethresear.ch/t/why-enshrine-proposer-builder-separation-a-viable-path-to-epbs/). This design is a nuanced iteration of previous proposals, integrating elements of Vitalik Buterin's two-slot design and enhancing it with a headlock mechanism to safeguard builders from proposer equivocations. Here, we delve into the key components of TBHL and its operational mechanics, drawing on the detailed explanation provided[^4].
 
 **TBHL Design Overview**
 
@@ -280,7 +279,7 @@ The TBHL proposal stands as a testament to the ongoing efforts to refine Ethereu
 
 ### Payload-Timeliness Committee (PTC)
 
-The Payload-Timeliness Committee (PTC) proposal is a design for enshrining Proposer-Builder Separation (ePBS) within the Ethereum protocol. It represents an evolution of the mechanism to determine block validity and includes a subset of validators who vote on the timeliness of a block's payload[^7].
+The Payload-Timeliness Committee (PTC) proposal is a design for enshrining PBS (ePBS) within the Ethereum protocol. It represents an evolution of the mechanism to determine block validity and includes a subset of validators who vote on the timeliness of a block's payload[^7][^12].
 
 #### High-Level Overview
 
@@ -332,15 +331,15 @@ Honest attestors will consider the payload-timeliness when casting their votes. 
 
 - The PT votes influence the fork-choice weight but do not create separate forks.
 - The payload view informs subsequent committee votes, which usually align with the proposer.
-- Builders do not receive a proposer boost or explicit fork-choice weight.
+- In the current ePBS design[^12], builders receive a proposer boost. They don't explicitly create fork choice weight between different forks. Instead, they boost or "deboost" the current block by revealing or withholding it.
 
 ### Protocol-Enforced Proposer Commitments (PEPC)
 
-PEPC, a conceptual extension and generalization of PBS, introduces a more flexible and secure way for proposers (validators) to commit to the construction of blocks. Unlike the existing MEV-Boost mechanism, which relies on out-of-protocol agreements between proposers and builders/relays, PEPC aims to enshrine these commitments within the Ethereum protocol itself, offering a trustless and permissionless infrastructure for these interactions[^10][^11].
+Protocol-Enforced Proposer Commitments (PEPC), a conceptual extension and generalization of PBS, introduces a more flexible and secure way for proposers (validators) to commit to the construction of blocks. Unlike the existing MEV-Boost mechanism, which relies on out-of-protocol agreements between proposers and builders/relays, PEPC aims to enshrine these commitments within the Ethereum protocol itself, offering a trustless and permissionless infrastructure for these interactions[^10][^11].
 
 #### Benefits of PEPC
 
-The introduction of Protocol-Enforced Proposer Commitments (PEPC) into Ethereum's ecosystem carries both promising benefits and notable disadvantages, reflecting the complex balance between innovation, security, scalability, and usability. Here's a detailed look at these aspects:
+The introduction of PEPC into Ethereum's ecosystem carries both promising benefits and notable disadvantages, reflecting the complex balance between innovation, security, scalability, and usability. Here's a detailed look at these aspects:
 
 **Enhanced Security and Trustlessness:**
 
@@ -352,7 +351,7 @@ By allowing for programmable contracts between proposers and builders, PEPC intr
 
 **Decentralization of MEV Opportunities:**
 
-PEPC could potentially lead to a more equitable distribution of Maximal Extractable Value (MEV) opportunities among validators. By embedding diverse commitment mechanisms into the protocol, it reduces the risk of centralizing these opportunities in the hands of a few large operators.
+PEPC could potentially lead to a more equitable distribution of MEV opportunities among validators. By embedding diverse commitment mechanisms into the protocol, it reduces the risk of centralizing these opportunities in the hands of a few large operators.
 
 **Scalability and Efficiency Improvements:**
 
@@ -496,7 +495,7 @@ PEPC offers several compelling use cases[^11]:
 
 #### Relationship and Differences to EigenLayer
 
-PEPC and Eigenlayer have a complementary relationship, each addressing different aspects of Ethereum's scalability, security, and decentralization, while also sharing a common goal of enhancing the network's efficiency and flexibility.
+PEPC and Eigenlayer have a complementary relationship, each addressing different aspects of Ethereum's scalability, security, and decentralization, while also sharing a common goal of enhancing the network's efficiency and flexibility[^14].
 
 - **Security Layering:** Eigenlayer introduces a mechanism to extend Ethereum's security to additional layers and services. In contrast, PEPC focuses on embedding more sophisticated and flexible commitment mechanisms within the Ethereum protocol itself. While Eigenlayer seeks to augment Ethereum's security model externally, PEPC aims to enhance the internal workings of the Ethereum main chain, specifically around block proposal and transaction inclusion processes.
 
@@ -554,6 +553,9 @@ Given the complex landscape and the potential for significant shifts in Ethereum
 - [ePBS Breakout Room](https://www.youtube.com/watch?v=63juNVzd1P4)
 - [Unbundling PBS: Towards protocol-enforced proposer commitments (PEPC)](https://ethresear.ch/t/unbundling-pbs-towards-protocol-enforced-proposer-commitments-pepc/13879/1)
 - [PEPC FAQ](https://efdn.notion.site/PEPC-FAQ-0787ba2f77e14efba771ff2d903d67e4)
+- [ePBS specification notes](https://hackmd.io/@potuz/rJ9GCnT1C)
+- [Minimal ePBS without Max EB and 7002](https://github.com/potuz/consensus-specs/pull/2)
+- [EigenLayer protocol](https://docs.eigenlayer.xyz/eigenlayer/overview/whitepaper)
 
 
 
@@ -569,3 +571,6 @@ Given the complex landscape and the potential for significant shifts in Ethereum
 [^9]: https://www.youtube.com/watch?v=63juNVzd1P4
 [^10]: https://ethresear.ch/t/unbundling-pbs-towards-protocol-enforced-proposer-commitments-pepc/13879/1
 [^11]: https://efdn.notion.site/PEPC-FAQ-0787ba2f77e14efba771ff2d903d67e4
+[^12]: https://hackmd.io/@potuz/rJ9GCnT1C
+[^13]: https://github.com/potuz/consensus-specs/pull/2
+[^14]: https://docs.eigenlayer.xyz/eigenlayer/overview/whitepaper

--- a/docs/wiki/research/PBS/ePBS.md
+++ b/docs/wiki/research/PBS/ePBS.md
@@ -509,6 +509,93 @@ In principle, if the value at stake in activities or assets secured by Eigenlaye
 
 In a broader Ethereum ecosystem context, PEPC and Eigenlayer could be seen as complementary, with Eigenlayer expanding Ethereum's security and utility beyond its core protocol and PEPC enhancing the efficiency and flexibility within the core protocol itself. Implementing both could lead to a scenario where Ethereum not only becomes more efficient and adaptable in handling transactions and block construction but also extends its security guarantees to a broader range of decentralized applications and services.
 
+## ePBS Specifications
+
+The current ePBS specification[^12][^13] addresses a critical issue in Ethereum's current implementation of PBS. Traditionally, both proposers and builders have had to rely on intermediaries through MEV-Boost, which introduces trust and censorship concerns as outlined above. The ePBS framework modifies this dynamic by changing the necessity of intermediaries ("must") to an option ("may"), allowing for a more trustless interaction within the Ethereum ecosystem. It incorporates EIP 7251 and EIP 7002, which are integral to its implementation. 
+
+EIP-7251 aims to increase the maximum effective balance (Max EB) for Ethereum validators to 2048 ETH while keeping a minimum stake of 32 ETH, reducing the total number of validators without compromising security. EIP-7002 introduces a mechanism allowing validators to trigger exits from the beacon chain using their execution layer (0x01) withdrawal credentials, enhancing flexibility and security for staking operations.
+
+### Specifications Overview
+
+**Main Improvements of the ePBS specification:**
+
+**Trust Minimization**: It minimizes the necessity of trust in intermediaries by allowing proposers and builders to operate more independently, reducing the risk of manipulations and trust dependencies.
+
+**Minimal Changes for Compatibility**: The design implements the least number of changes necessary to maintain compatibility with current consensus and execution client operations. It adheres to the existing 12-second slot time, ensuring continuity and stability in the network's operation.
+
+**Censorship Resistance**: It enhances censorship resistance by incorporating forward forced inclusion lists as per EIP-7547, ensuring that certain transactions must be included, which helps in maintaining network integrity.
+
+**Layer Enhancements**: The changes are primarily in the consensus layer (CL), with minimal adjustments required on the Execution Layer (EL), mainly related to the handling of inclusion lists.
+
+**Safety Guarantees**:
+    - **Proposer Safety**: It ensures that proposers are protected against 1-slot reorganization attacks by colluding proposers and builders, even those controlling network topology with up to 20% of the stake.
+    - **Builder Safety**: Guarantees are in place for builders against collusion and manipulation by consecutive proposers, including measures to ensure the safety of both withheld and revealed payloads.
+    - **Unbundling Guarantees**: Builders are protected under all attack scenarios, ensuring integrity in transaction handling and execution.
+
+**Self-Building for Validators**: Validators retain the capability to self-build their payloads, which is crucial for maintaining independence and flexibility.
+
+**Composability**: The specification is designed to be composable with other mechanisms like slot auctions or execution ticket auctions, enhancing flexibility and potential for future innovations.
+
+
+**Implementation Details:**
+
+The ePBS specification introduces specific roles and responsibilities:
+- **Builders**: Validators that submit bids for payload commitments.
+- **PTC (Payload Timeliness Committee)**: A new committee that verifies the timeliness and validity of payloads.
+
+During each slot, proposers collect bids, and upon selecting a bid, they submit their blocks with a signed commitment from the builder. Validators then adjust financial credits between builders and proposers based on these commitments. Builders later reveal their execution payloads, fulfilling their obligations. The slot outcomes can vary—missed, empty, or full—based on the production and revelation of the blocks, with the PTC playing a critical role in determining the nature of the slot's conclusion.
+
+
+### Detailed Processes and Timelines
+
+
+#### Anatomy of a Slot Timeline
+
+
+#### Inclusion List Timeline
+
+
+#### Execution Payload's Timeline
+
+
+#### Payload Attestation's Timeline
+
+
+#### Beacon Block's Timeline
+
+
+### Validator and Builder Specific Functions
+
+
+#### Honest Validator Behavior
+
+
+#### Honest Builder Behavior
+
+
+### Security and Safety Considerations
+
+
+#### Security analysis of proposer and builder interactions
+
+
+#### Forkchoice Considerations
+
+
+#### Analysis of Potential Reorg and Withholding Attacks
+
+
+### Enhancements and Benefits
+
+
+### System Modifications and Optional Changes
+
+
+### Comparisons and Advantages
+
+
+
+
 ## Open Questions in ePBS
 
 There are some interesting and challenging open questions highlighted by Mike in enshrining PBS (ePBS) in Ethereum Protocol[^5].

--- a/docs/wiki/research/PBS/ePBS.md
+++ b/docs/wiki/research/PBS/ePBS.md
@@ -970,8 +970,27 @@ class SignedBidRequest(container):
 - **Spam Protection**: The global topic can be protected against spam by only allowing the highest value bid received for a given parent block hash to be gossiped, and restricting to one message per builder per slot.
 
 
-
 #### Security analysis of proposer and builder interactions
+
+**Builder Reveal Safety**
+- **Scenario**: Collusion between proposers to reorganize the payload of a builder who has revealed their payload timely.
+- **Outcome**: The security design ensures that the builder's payload cannot be reorganized by subsequent proposers as long as the attackers do not control more than a specific threshold of the stake (up to 40% in this example).
+- **Key Equation**: The revealed payload remains secure if \(RB > PB\), where \(RB\) is the builder's reveal boost and \(PB\) is the proposer boost.
+
+**Builder Withholding Safety**
+- **Scenario**: Builder decides to withhold the payload due to the late arrival of the consensus block, aiming to avoid penalties.
+- **Outcome**: The (block, slot) voting mechanism supports the builder's decision to withhold the payload without penalties if the block is not the head of the chain or arrives late.
+- **Effective Safety**: The builder is safeguarded against attacks where proposers manipulate block timing to force a payload reveal, ensuring the builder is not forced to pay if the conditions for a safe reveal are not met.
+
+**Proposer Safety**
+- **Scenario**: Attempts to reorganize the chain through collaboration between builders and the next proposer.
+- **Outcome**: Analysis shows that as long as the attackers control less than 20% of the stake, proposers who act honestly and reveal their blocks timely are guaranteed inclusion on the chain.
+- **Detailed Analysis**: Demonstrates the resilience of the system against both ex-anti and post-anti reorganization attempts, maintaining the integrity of honest proposers' blocks against collusion and network control.
+
+**General Security Considerations**
+- The proposed design handles different payload statuses effectively by ensuring that votes only support chains consistent with PTC decisions.
+- Inclusion list availability plays a crucial role in determining the canonical head, enhancing ledger integrity by emphasizing validated inclusions.
+- Payload boosts (both for revealing and withholding) play a critical role in adjusting the weight calculations during fork choice, which can influence chain reorganizations and stability based on payload availability and actions.
 
 
 #### Forkchoice Considerations

--- a/docs/wiki/research/PBS/ePBS.md
+++ b/docs/wiki/research/PBS/ePBS.md
@@ -530,9 +530,7 @@ EIP-7251 aims to increase the maximum effective balance (Max EB) for Ethereum va
 **Safety Guarantees**:
 
 - **Proposer Safety**: It ensures that proposers are protected against 1-slot reorganization attacks by colluding proposers and builders, even those controlling network topology with up to 20% of the stake.
-
 - **Builder Safety**: Guarantees are in place for builders against collusion and manipulation by consecutive proposers, including measures to ensure the safety of both withheld and revealed payloads.
-
 - **Unbundling Guarantees**: Builders are protected under all attack scenarios, ensuring integrity in transaction handling and execution.
 
 **Self-Building for Validators**: Validators retain the capability to self-build their payloads, which is crucial for maintaining independence and flexibility.
@@ -545,7 +543,6 @@ EIP-7251 aims to increase the maximum effective balance (Max EB) for Ethereum va
 The ePBS specification introduces specific roles and responsibilities:
 
 - **Builders**: Validators that submit bids for payload commitments.
-
 - **PTC (Payload Timeliness Committee)**: A new committee that verifies the timeliness and validity of payloads.
 
 During each slot, proposers collect bids, and upon selecting a bid, they submit their blocks with a signed commitment from the builder. Validators then adjust financial credits between builders and proposers based on these commitments. Builders later reveal their execution payloads, fulfilling their obligations. The slot outcomes can vary—missed, empty, or full—based on the production and revelation of the blocks, with the PTC playing a critical role in determining the nature of the slot's conclusion.

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -439,3 +439,5 @@ subnets
 slashings
 slashing
 unaggregated
+Mitigations
+includable

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -435,3 +435,4 @@ mortem
 deboost
 Composability
 composable
+subnets

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -444,3 +444,4 @@ includable
 pubsub
 attester
 fulfillments
+incentivized

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -443,3 +443,4 @@ Mitigations
 includable
 pubsub
 attester
+fulfillments

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -433,3 +433,5 @@ devnet
 shadowfork
 mortem
 deboost
+Composability
+composable

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -445,3 +445,5 @@ pubsub
 attester
 fulfillments
 incentivized
+RB
+WB

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -442,3 +442,4 @@ unaggregated
 Mitigations
 includable
 pubsub
+attester

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -441,3 +441,4 @@ slashing
 unaggregated
 Mitigations
 includable
+pubsub

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -436,3 +436,6 @@ deboost
 Composability
 composable
 subnets
+slashings
+slashing
+unaggregated

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -432,3 +432,4 @@ Xatu
 devnet
 shadowfork
 mortem
+deboost


### PR DESCRIPTION
## Wiki PR Checklist


- [x] Added a correction suggested by Potuz on PTC section where builder can receive proposer boost per the current ePBS design specs.
- [x] Small grammar changes
- [x] Add a ePBS design specs section.
- [x] Local check on spelling errors and missing words for the wordlist.
