### PR TITLE
Changed the epbs specs URL, simplified PEPC benefits, disadvantages, and tradeoffs sections into one section

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -61,7 +61,7 @@
     - [MEV-boost](/wiki/research/PBS/mev-boost.md)
   - [PBS](/wiki/research/PBS/pbs.md)
     - [ePBS](/wiki/research/PBS/ePBS.md)
-      - [ePBS Design Specs](/wiki/research/PBS/PTC-Specs.md)
+      - [ePBS Design Specs](/wiki/research/PBS/ePBS-Specs.md)
     - [PTC](/wiki/research/PBS/PTC.md)
     - [PEPC](/wiki/research/PBS/PEPC.md)
     - [TBHL](/wiki/research/PBS/TBHL.md)

--- a/docs/wiki/research/PBS/PEPC.md
+++ b/docs/wiki/research/PBS/PEPC.md
@@ -2,75 +2,26 @@
 
 Protocol-Enforced Proposer Commitments (PEPC), a conceptual extension and generalization of [PBS](/docs/wiki/research/PBS/pbs.md), introduces a more flexible and secure way for proposers (validators) to commit to the construction of blocks. Unlike the existing [MEV-Boost](/docs/wiki/research/PBS/mev-boost.md) mechanism, which relies on out-of-protocol agreements between proposers and builders/relays, PEPC aims to enshrine these commitments within the Ethereum protocol itself, offering a trustless and permissionless infrastructure for these interactions[^1][^2].
 
-## Benefits of PEPC
+## Benefits and Related Trade-offs of PEPC
+- **Enhanced Security and Trustlessness:**
+  - **Benefit:** Enforces agreements within the protocol, reducing reliance on external parties and minimizing the potential for manipulation.
+  - **Trade-off (Security vs. Overhead):** While security is enhanced, this internalization increases computational demands, potentially impacting network efficiency and scalability.
 
-The introduction of PEPC into Ethereum's ecosystem carries both promising benefits and notable disadvantages, reflecting the complex balance between innovation, security, scalability, and usability. Here's a detailed look at these aspects:
+- **Increased Flexibility in Block Construction:**
+  - **Benefit:** Enables programmable contracts between proposers and builders, supporting diverse block construction scenarios.
+  - **Trade-off (Flexibility vs. Complexity):** This flexibility introduces complexity, which could limit participation to technically advanced users and raise barriers to entry.
 
-**Enhanced Security and Trustlessness:**
+- **Decentralization of MEV Opportunities:**
+  - **Benefit:** Promotes a more equitable distribution of MEV among validators.
+  - **Trade-off (Decentralization of MEV vs. Risk of Centralization):** While aiming to decentralize MEV, the complexity required might still favor larger, more sophisticated operators.
 
-PEPC's primary advantage lies in its ability to enforce agreements between proposers and builders within the Ethereum protocol itself, minimizing trust assumptions. This internalization of commitments enhances security by making it harder for external parties to manipulate transaction inclusion or exploit the proposer-builder relationship.
+- **Scalability and Efficiency Improvements:**
+  - **Benefit:** Streamlines block construction and validation processes, enhancing overall network scalability.
+  - **Trade-off (Long-term Scalability vs. Short-term Performance):** Initial impacts on network performance may occur as validators adjust to new complexities.
 
-**Increased Flexibility in Block Construction:**
-
-By allowing for programmable contracts between proposers and builders, PEPC introduces a high degree of flexibility. This can accommodate a variety of block construction scenarios, from full blocks to partial blocks and future slot auctions, enabling more efficient use of block space.
-
-**Decentralization of MEV Opportunities:**
-
-PEPC could potentially lead to a more equitable distribution of MEV opportunities among validators. By embedding diverse commitment mechanisms into the protocol, it reduces the risk of centralizing these opportunities in the hands of a few large operators.
-
-**Scalability and Efficiency Improvements:**
-
-The system aims to optimize the process of block construction and validation, potentially reducing the overhead associated with these tasks. This could contribute to the overall scalability and efficiency of the Ethereum network, aligning with its long-term goals.
-
-**Economic Innovation:**
-
-PEPC opens up new avenues for economic innovation within Ethereum. By enabling different types of transactions and block construction contracts, it could foster novel economic models and incentives, enhancing the dynamism and diversity of the Ethereum economy.
-
-## Disadvantages of PEPC
-
-**Complexity and Implementation Challenges:**
-The flexible and generalized nature of PEPC introduces significant complexity into the Ethereum protocol. Designing, implementing, and maintaining such a system poses substantial technical challenges, increasing the risk of bugs, vulnerabilities, and unintended consequences.
-
-**Increased Computational Overhead:**
-Enforcing proposer commitments within the protocol could lead to increased computational overhead for validators, impacting the network's performance. This might necessitate more powerful hardware or sophisticated optimization techniques to maintain efficiency.
-
-**Potential for Centralization:**
-While PEPC aims to decentralize MEV opportunities, its complexity could inadvertently favor large, technically sophisticated operators capable of navigating the intricacies of the system. This could counteract efforts to decentralize the network further.
-
-**Economic Uncertainty:**
-The introduction of PEPC could disrupt existing economic models and incentives within Ethereum, leading to uncertainty. Adjusting to new mechanisms for transaction inclusion and block construction may require time, potentially impacting network stability and user experience.
-
-**Difficulty in Balancing Flexibility and Security:**
-Finding the right balance between the flexibility offered by PEPC and the need to maintain a secure, reliable network is challenging. Too much flexibility could make the system unwieldy and difficult to secure, while too little could stifle innovation and efficiency.
-
-## Tradeoffs of Implementation of PEPC
-
-The implementation of PEPC in Ethereum involves several trade-offs, reflecting a balance between advancing the protocol's capabilities and managing new complexities and risks. These trade-offs highlight the nuanced considerations necessary to evolve Ethereum's infrastructure responsibly:
-
-**Trade-off 1: Flexibility vs. Complexity**
-
-- **Flexibility:** PEPC introduces a highly flexible framework for proposers and builders, allowing a variety of customized and programmable commitments. This flexibility can lead to more efficient use of block space and innovative economic arrangements.
-- **Complexity:** With increased flexibility comes heightened complexity in protocol design, implementation, and operation. This complexity can raise the barrier to entry for validators and builders, potentially centralizing participation to those with significant technical resources.
-
-**Trade-off 2: Security vs. Overhead**
-
-- **Security:** By embedding proposer commitments directly into the protocol, PEPC enhances the trustlessness and security of block construction, reducing reliance on external parties and minimizing the potential for manipulation.
-- **Overhead:** Implementing these commitments within the Ethereum protocol increases computational and operational overhead. Validators may face higher demands on processing and storage, impacting the network's efficiency and scalability.
-
-**Trade-off 3: Economic Innovation vs. Stability**
-
-- **Economic Innovation:** PEPC opens the door to new economic models and incentive structures within Ethereum, potentially improving the distribution of MEV and fostering a more dynamic and fair ecosystem.
-- **Stability:** These new economic models introduce uncertainty and may disrupt existing revenue streams and participation incentives. Adjusting to these changes could pose challenges for validators, builders, and users, affecting network stability and predictability.
-
-**Trade-off 4: Decentralization of MEV vs. Risk of Centralization**
-
-- **Decentralization of MEV:** By enabling a broader range of proposer-builder arrangements, PEPC aims to distribute MEV opportunities more widely among participants, aligning with Ethereum's decentralization goals.
-- **Risk of Centralization:** The complexity and technical demands of navigating PEPC could inadvertently favor larger, more sophisticated operators, potentially centralizing control and undermining the objective of broadening participation.
-
-**Trade-off 5: Long-term Scalability vs. Short-term Performance**
-
-- **Long-term Scalability:** PEPC's innovations could contribute to Ethereum's scalability over the long term by optimizing block space usage and enabling more sophisticated transaction inclusion mechanisms.
-- **Short-term Performance:** The introduction of PEPC and the transition to its mechanisms may initially impact the network's performance, as validators and the infrastructure adapt to the increased complexity and computational demands.
+- **Economic Innovation:**
+  - **Benefit:** Fosters novel economic models by allowing new types of transactions and block constructions.
+  - **Trade-off (Economic Innovation vs. Stability):** Introduces economic models that could disrupt established revenue structures and impact stability.
 
 ## How would PEPC work?
 

--- a/docs/wiki/research/PBS/PTC.md
+++ b/docs/wiki/research/PBS/PTC.md
@@ -89,7 +89,7 @@ Honest attestors will consider the payload-timeliness when casting their votes. 
 - The payload view informs subsequent committee votes, which usually align with the proposer.
 - In the current ePBS design[^2][^3], builders receive a proposer boost. They don't explicitly create fork choice weight between different forks. Instead, they boost or "deboost" the current block by revealing or withholding it.
 
-The [ePBS design specs](/docs/wiki/research/PBS/PTC-Specs.md) has more details about the implementation specifications and flow.
+The [ePBS design specs](/docs/wiki/research/PBS/ePBS-Specs.md) has more details about the implementation specifications and flow.
 
 ## Resources 
 - [Payload-timeliness committee (PTC) – an ePBS design ](https://ethresear.ch/t/payload-timeliness-committee-ptc-an-epbs-design/16054)
@@ -97,7 +97,7 @@ The [ePBS design specs](/docs/wiki/research/PBS/PTC-Specs.md) has more details a
 - [ePBS Breakout Room](https://www.youtube.com/watch?v=63juNVzd1P4)
 - [Notes on Proposer-Builder Separation (PBS)](https://barnabe.substack.com/p/pbs)
 - [Mike Neuder - Towards Enshrined Proposer-Builder Separation](https://www.youtube.com/watch?v=Ub8V7lILb_Q)
-- [ePBS design specs](/docs/wiki/research/PBS/PTC-Specs.md)
+- [ePBS design specs](/docs/wiki/research/PBS/ePBS-Specs.md)
 
 ## References
 [^1]: https://ethresear.ch/t/payload-timeliness-committee-ptc-an-epbs-design/16054

--- a/docs/wiki/research/PBS/ePBS-Specs.md
+++ b/docs/wiki/research/PBS/ePBS-Specs.md
@@ -1,10 +1,10 @@
 # ePBS Design Specifications
 
-The current ePBS specification[^1][^2] addresses a critical issue in Ethereum's current implementation of PBS. Traditionally, both proposers and builders have had to rely on intermediaries through [MEV-Boost](/docs/wiki/research/PBS/mev-boost.md), which introduces trust and censorship concerns as outlined in the [ePBS document](/docs/wiki/research/PBS/ePBS.md). The ePBS specifications framework modifies this dynamic by changing the necessity of intermediaries ("must") to an option ("may"), allowing for a more trustless interaction within the Ethereum ecosystem. 
+The [current ePBS specification](https://hackmd.io/@potuz/rJ9GCnT1C) and the [GitHub repo](https://github.com/potuz/consensus-specs/tree/epbs_stripped_out/specs/_features/epbs) address a critical issue in Ethereum's current implementation of PBS[^1][^2][^11]. Traditionally, both proposers and builders have had to rely on intermediaries through [MEV-Boost](/docs/wiki/research/PBS/mev-boost.md), which introduces trust and censorship concerns as outlined in the [ePBS document](/docs/wiki/research/PBS/ePBS.md). The ePBS specifications framework modifies this dynamic by changing the necessity of intermediaries ("must") to an option ("may"), allowing for a more trustless interaction within the Ethereum ecosystem. 
 
 ## Specifications Overview
 
-The ePBS specification is divided into separate components to build on top of the existing specifications of Ethereum components. 
+The [ePBS specification](https://github.com/potuz/consensus-specs/tree/epbs_stripped_out/specs/_features/epbs) is divided into separate components to build on top of the existing specifications of Ethereum components. 
 - `Beacon-chain.md`: This document specifies the beacon chain specifications of the ePBS feature[^6].
 - `Validator.md`: This document specifies the honest validator behavior specifications of the ePBS feature[^7].
 - `Builder.md`: This document specifies the honest builder specifications of the ePBS feature[^8].
@@ -481,4 +481,5 @@ The introduction of the ePBS fork brings sophisticated changes to the forkchoice
 [^7]: https://github.com/potuz/consensus-specs/blob/epbs_stripped_out/specs/_features/epbs/validator.md
 [^8]: https://github.com/potuz/consensus-specs/blob/epbs_stripped_out/specs/_features/epbs/builder.md
 [^9]: https://github.com/potuz/consensus-specs/blob/epbs_stripped_out/specs/_features/epbs/engine.md
-[^10]: https://github.com/potuz/consensus-specs/blob/epbs_stripped_out/specs/_features/epbs/fork-choice.md 
+[^10]: https://github.com/potuz/consensus-specs/blob/epbs_stripped_out/specs/_features/epbs/fork-choice.md
+[^11]: https://github.com/potuz/consensus-specs/tree/epbs_stripped_out/specs/_features/epbs 

--- a/docs/wiki/research/PBS/ePBS.md
+++ b/docs/wiki/research/PBS/ePBS.md
@@ -240,14 +240,14 @@ The [PTC proposal](/docs/wiki/research/PBS/PTC.md) has more details about the de
 
 ### ePBS PTC Specifications Overview
 
-The current ePBS specification[^15][^16] is divided into separate components to build on top of the existing specifications of Ethereum components. 
+The [current ePBS specification](https://hackmd.io/@potuz/rJ9GCnT1C) and the [GitHub repo](https://github.com/potuz/consensus-specs/tree/epbs_stripped_out/specs/_features/epbs) are divided into separate components to build on top of the existing specifications of Ethereum components[^15][^16][^23]. 
 - `Beacon-chain.md`: This document specifies the beacon chain specifications of the ePBS fork[^18].
 - `Validator.md`: This document specifies the honest validator behavior specifications of the ePBS fork[^19].
 - `Builder.md`: This document specifies the honest builder specifications of the ePBS fork[^20].
 - `Engine.md`: This document specifies the Engine APi changes due ePBS fork[^21].
 - `fork-choice.md`: This document specifies the changes to the fork-choice due to the ePBS fork[^22].
 
-The [ePBS design specs](/docs/wiki/research/PBS/PTC-Specs.md) has more details about the implementation specifications and flow.
+The [ePBS design specs](/docs/wiki/research/PBS/ePBS-Specs.md) has more details about the implementation specifications and flow.
 
 ### Protocol-Enforced Proposer Commitments (PEPC)
 
@@ -302,7 +302,8 @@ Given the complex landscape and the potential for significant shifts in Ethereum
 - [Minimal ePBS without Max EB and 7002](https://github.com/potuz/consensus-specs/pull/2)
 - [EigenLayer protocol](https://docs.eigenlayer.xyz/eigenlayer/overview/whitepaper)
 - [ePBS specification notes](https://hackmd.io/@potuz/rJ9GCnT1C)
-- [ePBS design specs repo](https://github.com/potuz/consensus-specs/pull/2)
+- [ePBS design specs PR](https://github.com/potuz/consensus-specs/pull/2)
+- [ePBS design specs GitHub repo](https://github.com/potuz/consensus-specs/tree/epbs_stripped_out/specs/_features/epbs)
 - [epbs - beacon-chain specs](https://github.com/potuz/consensus-specs/blob/epbs_stripped_out/specs/_features/epbs/beacon-chain.md)
 - [epbs - honest validator specs](https://github.com/potuz/consensus-specs/blob/epbs_stripped_out/specs/_features/epbs/validator.md)
 - [epbs - honest builder specs](https://github.com/potuz/consensus-specs/blob/epbs_stripped_out/specs/_features/epbs/builder.md)
@@ -333,3 +334,4 @@ Given the complex landscape and the potential for significant shifts in Ethereum
 [^20]: https://github.com/potuz/consensus-specs/blob/epbs_stripped_out/specs/_features/epbs/builder.md
 [^21]: https://github.com/potuz/consensus-specs/blob/epbs_stripped_out/specs/_features/epbs/engine.md
 [^22]: https://github.com/potuz/consensus-specs/blob/epbs_stripped_out/specs/_features/epbs/fork-choice.md 
+[^23]: https://github.com/potuz/consensus-specs/tree/epbs_stripped_out/specs/_features/epbs


### PR DESCRIPTION


## Wiki PR Checklist

- [x] Changed the ePBS specs URL to `ePBS-Specs.md`
- [x] Simplified and shortened the benefits, disvantages and tradeoffs sections of PEPC into a single section.
- [x] Updated the sidebar links to `ePBS-Specs.md` for the ePBS specs page
- [x] Local spellcheck
