### PR TITLE
Update el-specs.md

### DIFF
--- a/docs/wiki/EL/el-specs.md
+++ b/docs/wiki/EL/el-specs.md
@@ -190,6 +190,8 @@ $$
 \xi \equiv 8 \qquad (50)
 $$
 
+If H<sub>number</sub> = F<sub>number</sub>, it is special case of [London Hard Fork](https://eips.ethereum.org/EIPS/eip-1559?utm_source=chatgpt.com).
+
 | Symbol          | What it represents                         | value                                              | comments                                                                                                                   |
 | --------------- | ------------------------------------------ | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | $F(H) $ | Base Fee per Gas                           |                                                    | Paid be the sender as part of the Total Fee , The Base Fee is finally burnt by Execution Layer and taken out of the system |


### PR DESCRIPTION
F_london term was used but never mentioned what it was, so introduced this term, following the part where eqn 57 (h) is explained and added a link to the EIP1557 original docs.
![image](https://github.com/user-attachments/assets/495b9322-e709-4948-b7b0-a9c685771e0c)
