### PR TITLE
Update data-structures.md

### DIFF
--- a/docs/wiki/EL/data-structures.md
+++ b/docs/wiki/EL/data-structures.md
@@ -29,7 +29,7 @@ The image below depicts a simplified version of the working of a Merkle Tree:
 - The first level of non-leaf nodes contains the Hash of its child leaf nodes
   `Hash(1,2)`
 - The same process continues till we reach the top of the tree, which the Hash of all the previous Hashes
-  `Hash[Hash(1,2),Hash(3,4),Hash(5,6),Hash(7,8)]`
+  `Hash[Hash[Hash(1,2),Hash(3,4)],Hash[Hash(5,6),Hash(7,8)]]`
 
 More on [Merkle Trees in Ethereum](https://blog.ethereum.org/2015/11/15/merkling-in-ethereum)
 


### PR DESCRIPTION
Incorrect Hash Presentation of Root Hash:  
    Hash[Hash(1,2),Hash(3,4),Hash(5,6),Hash(7,8)]

corrected Hash Presentation of Root Hash: 
   Hash[ Hash [Hash(1,2),Hash(3,4)] , Hash[Hash(5,6),Hash(7,8)] ]


Reason: 
   1.Merkle trees are in a binary tree Format.
   2.So At Root Level Hash calculation it should have taken two hashes if its children nodes.
   3.But here It took Root Hash as Hash of 4  nodes at a Time.