### PR TITLE
Add call slides link to day16

### DIFF
--- a/docs/eps/day16.md
+++ b/docs/eps/day16.md
@@ -4,8 +4,7 @@ The introductory part of the study group is now over and we are now starting the
 
 For the first session of this week, we are diving into the consensus mechanism of Ethereum with Ben Edgington. Ben is a seasoned core contributor who worked on Teku consensus client, Optimism and is author of Eth2 Book, the annotated specification. 
 
-> Join the live talk by Ben on [Monday, 10.3. at 3PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250310T150000&p1=1440&p2=37&p3=136&p4=237&p5=923&p6=204&p7=671&p8=16&p9=41&p10=107&p11=28) to watch the lecture and ask questions directly. [Use this link to connect.](https://meet.ethereum.org/eps-office-hours) 
-
+> Join the live talk by Ben on [Monday, 10.3. at 3PM UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250310T150000&p1=1440&p2=37&p3=136&p4=237&p5=923&p6=204&p7=671&p8=16&p9=41&p10=107&p11=28) to watch the lecture and ask questions directly. [Use this link to connect.](https://meet.ethereum.org/eps-office-hours). You can view the [slides](https://docs.google.com/presentation/d/1mSn8JUfY88HvcCauLBkKRuy3f6YFlV9VcJptav0Ef24/edit#slide=id.p).
 
 ## Pre-reading
 


### PR DESCRIPTION
This PR adds link to the slides used in the call. The slides are an important resource as they contain many useful links.