### PR TITLE
chore: update evm data structures

### DIFF
--- a/docs/wiki/EL/evm.md
+++ b/docs/wiki/EL/evm.md
@@ -136,21 +136,24 @@ Identifying opcodes from operands is straightforward. Currently, only `PUSH*` op
 
 Select Opcodes used in this discussion:
 
-| Opcode | Name     | Description                                        |
-| ------ | -------- | -------------------------------------------------- |
-| 60     | PUSH1    | Push 1 byte on the stack                           |
-| 01     | ADD      | Add the top 2 values of the stack                  |
-| 02     | MUL      | Multiply the top 2 values of the stack             |
-| 39     | CODECOPY | Copy code running in current environment to memory |
-| 51     | MLOAD    | Load word from memory                              |
-| 52     | MSTORE   | Store word to memory                               |
-| 53     | MSTORE8  | Store byte to memory                               |
-| 59     | MSIZE    | Get the byte size of the expanded memory           |
-| 54     | SLOAD    | Load word from storage                             |
-| 55     | SSTORE   | Store word to storage                              |
-| 56     | JUMP     | Alter the program counter                          |
-| 5B     | JUMPDEST | Mark destination for jumps                         |
-| f3     | RETURN   | Halt execution returning output data               |
+| Opcode | Name         | Description                                        |
+| ------ | --------     | -------------------------------------------------- |
+| 60     | PUSH1        | Push 1 byte on the stack                           |
+| 01     | ADD          | Add the top 2 values of the stack                  |
+| 02     | MUL          | Multiply the top 2 values of the stack             |
+| 39     | CODECOPY     | Copy code running in current environment to memory |
+| 51     | MLOAD        | Load word from memory                              |
+| 52     | MSTORE       | Store word to memory                               |
+| 53     | MSTORE8      | Store byte to memory                               |
+| 59     | MSIZE        | Get the byte size of the expanded memory           |
+| 54     | SLOAD        | Load word from storage                             |
+| 55     | SSTORE       | Store word to storage                              |
+| 56     | JUMP         | Alter the program counter                          |
+| 5B     | JUMPDEST     | Mark destination for jumps                         |
+| f3     | RETURN       | Halt execution returning output data               |
+| 35     | CALLDATALOAD | Copy 32 bytes from calldata to stack               |
+| 36     | CALLDATASIZE | Push total size (in bytes) of calldata to stack    |
+| 37     | CALLDATACOPY | Copy input data from calldata to memory            |
 
 Refer [Appendix H of Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf) for a comprehensive list.
 
@@ -161,13 +164,27 @@ Ethereum clients such as [geth](https://github.com/ethereum/go-ethereum) impleme
 
 We have covered **what** EVM is, let's explore **how** it works.
 
+# EVM Data Storage
+
+The EVM has four main places to store data during execution:
+- **Stack**
+- **Memory**
+- **Storage**
+- **Calldata**
+
+Let's explore each of these data stores more in depth.
+
 ## Stack
 
 Stack is a simple data structure with two operations: **PUSH** and **POP**. Push adds an item to top of the stack, while pop removes the top-most item. Stack operates on Last-In-First-Out (LIFO) principle - the last element added is the first removed. If you try to pop from an empty stack, a **stack underflow error** occurs.
 
+Since the stack is where most opcodes operate, it is responsible for holding the values used to read from and write to **memory** and **storage**, which we'll detail later.
+
+The primary utility of the stack by the EVM is to store intermediate values in computations.
+
 ![EVM stack](../../images/evm/stack.gif)
 
-> The EVM stack has a maximum size of 1024 items.
+> The EVM stack has a maximum size of 1024 items consisting of 32 bytes each and is reset after each contract execution. Only the top 16 items are easily accessible. If you run out of stack, the contract execution will fail.
 
 During bytecode execution, EVM stack functions as a _scratchpad_: opcodes consume data from the top and push results back (See the `ADD` opcode below). Consider a simple addition program:
 
@@ -177,7 +194,9 @@ Reminder: All values are in hexadecimal, so `0x06 + 0x07 = 0x0d (decimal: 13)`.
 
 Let's take a moment to celebrate our first EVM assembly code 🎉.
 
-## Program counter
+### Program counter
+
+Recall that the bytecode is a flat array of bytes with each opcode being a 1 byte.  The EVM needs a way to track what is the next byte (opcode) to execute in the bytecode array.  This is where the EVM **program counter** comes in. It will keep track of the next opcode's offset, which is the location in the byte array of the next instruction to execute on the stack.
 
 In the example above, the values on the left of the assembly code represent the byte offset (starting at 0) of each opcode within the bytecode:
 
@@ -187,7 +206,9 @@ In the example above, the values on the left of the assembly code represent the 
 | 60 07    | PUSH1 07 | 2                              | 02            |
 | 01       | ADD      | 1                              | 04            |
 
-EVM **program counter** stores the byte offset of the next opcode (highlighted) to be executed.
+Notice how the table above doesn't include offset 01. This is because the operand 06 takes position of offset 01, and the same concept applies for operand 07 taking position of offset 03.
+
+Essentially, the **program counter** ensures the EVM knows the position of each next instruction to execute and when to stop executing as illustrated in the example below.
 
 ![EVM program counter](../../images/evm/program-counter.gif)
 
@@ -202,7 +223,7 @@ The code runs in an infinite loop, repeatedly adding 7. It introduces two new op
 
 > High level languages like [Solidity](https://soliditylang.org/) leverage jumps for constructs like if conditions, for loops, and internal functions calls.
 
-## Gas
+### Gas
 
 Our innocent little program may seem harmless. However, infinite loops in EVM pose a significant threat: they can **devour resources**, potentially causing network [**DoS attacks**.](https://en.wikipedia.org/wiki/Denial-of-service_attack)
 
@@ -222,7 +243,7 @@ EVM memory is a byte array of $2^{256}$ (or [practically infinite](https://www.t
 
 ![EVM Memory](../../images/evm/evm-memory.gif)
 
-Unlike stack, which provides data to individual instructions, memory stores ephemeral data that is relevant to the entire program.
+Unlike stack, which provides data to individual instructions, memory stores ephemeral data that is relevant to the entire program.  This data often includes return data and dynamic types such as arrays that will be mutated during the contract function execution.
 
 ### Writing to memory
 
@@ -258,9 +279,21 @@ EVM doesn't have a direct equivalent to `MSTORE8` for reading. You must read the
 
 > EVM memory is shown as blocks of 32 bytes to illustrate how memory expansion works. In reality, it is a seamless sequence of bytes, without any inherent divisions or blocks.
 
+## Calldata
+The **calldata** memory type is very similar to **Memory** as discussed above in that they both store dynamically sized data that is removed after contract execution. However, the **calldata** memory structure stores read-only data originating from a function's parameters.  The EVM will store the parameter as calldata since it's cheaper than copying the value to **Memory**.
+
+###  Reading from calldata
+If the transaction calling this smart contract passes in calldata, the inputted data can be loaded using the `CALLDATALOAD` opcode, which reads 32 bytes from calldata at a given offset and pushes it onto the stack once the program counter reaches its position in the bytecode. More info on the `CALLDATALOAD` opcode can be found [here](https://veridelisi.medium.com/learn-evm-opcodes-v-a59dc7cbf9c9).
+
+
+Additional opcodes for **calldata** include:
+- `CALLDATASIZE`: Puts a number onto the stack, where that number is the number of bytes in calldata.
+- `CALLDATACOPY`: Copies a segment of calldata to memory and takes three stack arguments: destination memory offset, calldata offset, and length in bytes.
+
+
 ## Storage
 
-Storage is designed as a **word-addressed word array**. Unlike memory, storage is associated with an Ethereum account and is **persisted** across transactions as part of the world state.
+Storage is designed as a **word-addressed word array**. Unlike memory, storage is associated with an Ethereum account and is **persisted** across transactions as part of the world state.  It can be thought of as the **database** associated with the smart contract, which is why it contains the contract's "state" variables. Storage size is fixed at 2^256 slots, 32 bytes each.
 
 ![EVM Storage](../../images/evm/evm-storage.jpg)
 
@@ -268,13 +301,13 @@ Storage can only be accessed via the code of its associated account. External ac
 
 ## Writing to storage
 
-`SSTORE` takes two values from the stack: a storage **slot** and a 32-byte **value**. It then writes the value to storage of the account.
+`SSTORE` takes two values from the stack: a storage **slot** and a 32-byte **value**. It then writes the value to storage of the account.  Notice: Slots can be thought of as the basic unit of storage, so when writing to storage, we deal with slots as opposed to individual bytes.  Depending upon the data type being stored, the value will take up a full slot or could be combined with other data in the same slot if the their combined length is less than 32 bytes long. More info on how different data types are packed into slots can be found [here](https://medium.com/coinmonks/solidity-storage-how-does-it-work-8354afde3eb).
 
 ![EVM Storage write](../../images/evm/sstore.gif)
 
 We've been running a contract account's bytecode all this time. Only now we see the account and the world state, and it matches the code inside the EVM.
 
-Again, it’s important to note that storage is not part of the EVM itself, rather the currently executing contract account.
+Again, it’s important to note that storage is not part of the EVM itself, rather the currently executing contract account.  More specifically, the contract account contains a **storage root*** that points to a separate Merkle Patricia Trie for that contract's storage.
 
 The example above shows only a small section of the account's storage. Like memory, all the values in storage are well-defined as zero.
 
@@ -290,6 +323,8 @@ Notice that the storage value persists between examples, demonstrating its persi
 > Check out the wiki on [transaction](/wiki/EL/transaction.md) to see EVM in action.
 
 ## Wrapping up
+
+We've explored how opcodes are the core instructions executed by the EVM, operating on the stack to perform computations. Computed results can be stored ephemerally in memory or persisted in contract storage.
 
 Developers rarely write EVM assembly code directly unless performance optimization is crucial. Instead, most developers work with higher-level languages like [Solidity](https://soliditylang.org/), which is then compiled into bytecode.
 
@@ -338,6 +373,10 @@ The resources below has been categorized into different sections based on differ
 - 📝 Zaryab Afser, ["Journey of smart contracts from Solidity to Bytecode"](https://www.decipherclub.com/ethereum-virtual-machine-article-series/)
 - 🎥 Ethereum Engineering Group, [EVM: From Solidity to byte code, memory and storage](https://www.youtube.com/watch?v=RxL_1AfV7N4&t=2s)
 - 📝 Trust Chain, [7 part series about how Solidity uses EVM under the hood.](https://trustchain.medium.com/reversing-and-debugging-evm-smart-contracts-392fdadef32d)
+- [Learn EVM Opcodes](https://veridelisi.medium.com/learn-evm-opcodes-v-a59dc7cbf9c9) • [archived](https://web.archive.org/web/20240806231824/https://veridelisi.medium.com/learn-evm-opcodes-v-a59dc7cbf9c9)
+- [More on EVM Storage](https://medium.com/coinmonks/solidity-storage-how-does-it-work-8354afde3eb)  • [archived](https://web.archive.org/web/20230808231549/https://medium.com/coinmonks/solidity-storage-how-does-it-work-8354afde3eb)
+- [Storage, Memory, and Stack Overview](https://ethereum.stackexchange.com/questions/23720/usage-of-memory-storage-and-stack-areas-in-evm) • [archived](https://web.archive.org/web/20240529150647/https://ethereum.stackexchange.com/questions/23720/usage-of-memory-storage-and-stack-areas-in-evm)
+- [Calldata](https://learnevm.com/chapters/fn/calldata) • [archived](https://web.archive.org/web/20250306133755/https://learnevm.com/chapters/fn/calldata)
 
 ### Tools & EVM Puzzles
 


### PR DESCRIPTION
## Changes
- `docs/wiki/EL/evm.md` updated with:
  - contexted added to sections about stack, program counter,  memory, and storage to improve reader understanding of why these data structures exist
  - added `Calldata` section since it's another storage mechanism utilized by the EVM