### PR TITLE
Replace broken link of what-is-ethereum to a equivalent functional one

### DIFF
--- a/docs/eps/week1.md
+++ b/docs/eps/week1.md
@@ -15,7 +15,7 @@ For archive of the discussion during the talk, check the corresponding thread in
 This is an introductory talk which doesn't assume a lot of prior knowledge. Check some general requirements in [week 0](/eps/week0.md). Here are few more introductory materials to get you started:
 - [Inevitable Ethereum - World Computer](https://inevitableeth.com/home/ethereum/world-computer)
 - [Ethereum in 30 minutes](https://www.youtube.com/watch?v=UihMqcj-cqc)
-- [Ethereum.org docs](https://ethereum.org/what-is-ethereum)
+- [Ethereum.org docs](https://ethereum.org/en/what-is-ethereum/)
 
 Check out resources within the following text and additional reading. All resources will be explained in the week 1 presentation.
 


### PR DESCRIPTION
Original link to [Ethereum.org docs](https://ethereum.org/what-is-ethereum) is broken, returning a 404 error. The link was replaced by the equivalente one, with fixed address: https://ethereum.org/en/what-is-ethereum

original creator for review: [@taxmeifyoucan ](https://github.com/taxmeifyoucan)
