### PR TITLE
Removal of author review request in PRs template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,6 @@
 Thank you for contributing to the Protocol Wiki! Before you open a PR, make sure to read [information for contributors](https://epf.wiki/#/contributing) and take a look at following checklist:
 
 - [ ] Describe your changes, substitute this text with the information
-- [ ] If you are touching an existing piece of content, ask the original creator for review
 - [ ] If you need feedback for your content from wider community, share the PR in our Discord
 - [ ] Review changes to ensure there are no typos, see instructions bellow
 


### PR DESCRIPTION
With [mainteners](https://github.com/eth-protocol-fellows/protocol-studies/blob/maintainers/README.md#wiki-maintainers) defined for each section, is no longer necessary to ask for review from original creator of content. I suggest to remove this check item from PR template.