### PR TITLE
chore: add sync strategies

### DIFF
--- a/docs/wiki/EL/el-architecture.md
+++ b/docs/wiki/EL/el-architecture.md
@@ -26,7 +26,7 @@ The EVM produces data and modifies the state of the Ethereum network through a p
 
 **DevP2P**
 
-The interface for communicating with other  the execution layer clients. Transactions initially stored in the mempool, which serves as a repository for all incoming transactions, are disseminated by execution layer clients to other execution layer clients in the network using peer-to-peer communication. Every recipient of the transaction sent over the network confirms its validity before broadcasting it to the network.
+The interface for communicating with other execution layer clients. Transactions are initially stored in the mempool, which serves as a repository for all incoming transactions, and are disseminated by execution layer clients to other execution layer clients in the network using peer-to-peer communication. Every recipient of the transaction sent over the network confirms its validity before broadcasting it to the network.
 
 **JSON-RPC API**
 
@@ -173,12 +173,39 @@ At its core, Geth runs the Ethereum Virtual Machine (EVM), which processes smart
 
 🔗 [EVM Code in Geth]( https://github.com/ethereum/go-ethereum/blob/master/core/vm/evm.go#L90)
 
-##### Sync
+##### State Sync
 
-Execution client synchronizes the chain by downloading block data from its peers and verifying them using the block validation rule. Sync finishes when blockchain data is verified and clients catches up with the tip of the chain which enables building the latest state. 
+All execution clients require an up‑to-date world state to validate and build blocks. To bootstrap a new node's current state, clients leverage Ethereum’s DevP2P subprotocols: `eth/*` (wire protocol) for block headers, bodies, and receipts, and `snap/1` for creating state snapshots. Using these sub-protocols, clients can choose between two sync strategies, **full sync** or **snap sync**.  The difference between the snap synced node and a full block-by-block synced node is that a snap synced node started from an initial checkpoint that was more recent than the genesis block.
 
-Because it's inefficient to validate block by block and transaction by transaction since the genesis, EL clients employ other strategies to securely sync the tip of the chain, e.g. [snap sync](https://github.com/ethereum/devp2p/blob/master/caps/snap.md?plain=1#L1)
+Let's look at how the flows of both **full sync** and **snap sync** work.
 
+### Full Sync
+Full Sync trades absolute trustlessness for time and resources. You replay every block and transaction from genesis to tip, rebuilding the state trie step by step:
+1. Use `GetBlockHeaders` over the `eth/*` protocol to download every block header since genesis.
+2. Use `GetBlockBodies` to retrieve every block’s transactions and uncles.
+3. Sequentially execute each transaction in EVM order, updating the local trie at each block.
+4. Confirm that the local state trie’s root matches the tip’s root. Every state transition has been verified.
+
+This method guarantees maximal security but can take days on mainnet and consumes significant CPU, disk, and network resources.
+
+### Snap Sync
+Snap Sync reconstructs the pivot block's state by fetching only the trie leaves (accounts and storage slots) plus Merkle proofs, then separately downloading any needed contract bytecode, and finally rebuilding the tries locally:
+1. Choose a recently finalized block as your pivot block.
+2. Over eth/*, request that block’s header via `GetBlockHeaders` to learn its stateRoot. 
+3. Fetch headers up to the pivot via `eth/*`, so you know which state root to target.
+4. Download the leaves of the pivot block's world state trie and account storage trie in chunks.
+   - **Accounts**: uses `GetAccountRange` to pull contiguous world state trie leaf values.
+   - **Storage**: uses `GetStorageRanges` to pull consecutive storage slot leaf nodes for each account.
+5. Send `GetByteCodes` for every code hash found in the account bodies to get back the contract code for that account
+6. Locally insert every fetched leaf into a fresh trie, verifying each batch against the pivot root via Merkle proofs.
+
+After step 6, we have a snapshot of the pivot block's state. However, the blockchain is also progressing at the same time and invalidating some of the regenerated state data. This means it is also necessary to have a healing phase where errors in the state are fixed.  During healing, the client walks the reconstructed trie and verifies that it hashes to the pivot block’s stateRoot. Any missing or inconsistent trie nodes or bytecode blobs are fetched using targeted snap requests. Healing ensures the final state is complete and cryptographically valid, even if parts of the snapshot were stale, incomplete, or assembled from mixed sources.  
+
+At this point, we have a snapshot of the pivot block's state, so we apply the transactions of blocks following the pivot on the downloaded state to get to the tip of the chain.
+
+Snap Sync reduces mainnet bootstrap times from days to hours. Its trade‑off is that it's hardware intensive for the healing phase to be able to outpace trie changes from new blocks being produced.
+
+Both **full sync* and **snap sync** finishes when blockchain data is verified and clients catches up with the tip of the chain which enables building the latest state. 
 
 ##### Payload building
 
@@ -294,3 +321,6 @@ Read more about its [features](https://github.com/erthink/libmdbx#features). Add
 - [Engine Api Spec](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#payload-validation) • [archived](https://web.archive.org/web/20250318111700/https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#payload-validation)
 - [Engine API: A Visual Guide](https://hackmd.io/@danielrachi/engine_api) • [archived](https://web.archive.org/web/20241006232802/https://hackmd.io/@danielrachi/engine_api)
 - [Engine API | Mikhail | Lecture 21](https://youtu.be/fR7LBXAMH7g)
+- ["Snapping Snap Sync: Practical Attacks on Go Ethereum Synchronising Nodes" (ETH Zurich)](https://appliedcrypto.ethz.ch/content/dam/ethz/special-interest/infk/inst-infsec/appliedcrypto/research/TavernaPaterson-SnappingSnapSync.pdf)
+- [Geth Docs – Sync Modes](https://geth.ethereum.org/docs/fundamentals/sync-modes?utm_source=chatgpt.com) • [archived](https://web.archive.org/web/20240505050000/https://geth.ethereum.org/docs/fundamentals/sync-modes)
+- [YouTube – "How to Sync an Ethereum Node with Snap Sync"](https://www.youtube.com/watch?v=fk50UbUgkMM)

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -954,3 +954,5 @@ Wireshark
 SigP
 opcode's
 Karim
+trie's
+Synchronising


### PR DESCRIPTION
## Changes
- added how full sync and snap sync function


## Note
- this should probably go in the devp2p section. I'm thinking we make a gh issue to stating to move this context over there once the open devp2p PR's are closed out
