### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/md-lint.yaml
+++ b/.github/workflows/md-lint.yaml
@@ -8,7 +8,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: DavidAnson/markdownlint-cli2-action@v15
       continue-on-error: true
       with:

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -22,7 +22,7 @@ jobs:
       # for more information, see: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0