### PR TITLE
Explained an empty parameter I_blobVersionedHashes

### DIFF
--- a/docs/wiki/EL/el-specs.md
+++ b/docs/wiki/EL/el-specs.md
@@ -363,7 +363,7 @@ $$
 | $I_{chainId}$             | Identifier for the blockchain, ensuring transactions are signed for a specific chain.                                    |
 | $I_{traces}$              | A placeholder for execution traces, intended for future use or debugging purposes.                                       |
 | $I_{excessBlobGas}$       | Calculated from the parent block, it represents surplus gas allocated for blob transactions.                             |
-| $I_{blobVersionedHashes}$ |                                                                                                                          |
+| $I_{blobVersionedHashes}$ |                      the ordered list of versioned hashes of blobs that are attached to the current transaction.                                                                                                     |
 
 ## Gas Accounting
 


### PR DESCRIPTION
**This is the continuation of the previous PR about the parameter without any other commits.**
 
# Summary
Adds a concise explanation for the I_blobVersionedHashes execution
environment parameter.

## Motivation
The parameter previously lacked a clear description, making it unclear
what data is exposed to the EVM for blob-carrying transactions.

## Changes
Documented I_blobVersionedHashes as the ordered list of versioned hashes
of blobs attached to the current transaction

## Spec reference
EIP-4844 (Proto-Danksharding)