### PR TITLE
Add Pebble storage backend documentation for the Execution Layer

### DIFF
--- a/docs/wiki/EL/el-architecture.md
+++ b/docs/wiki/EL/el-architecture.md
@@ -302,7 +302,7 @@ TODO: Move relevant code from specs into EVM
 
 More details in the page on [EL data structures](/wiki/EL/data-structures.md).
 
-### Storage
+### Storage and database backend
 
 Blockchain and state data processed by execution client need to be stored in the disk. These are necessary to validate new blocks, verify history and to serve peers in the network. Client stores historical data, also called the ancient database, which include previous blocks. Another database of trie structure contains the current state and small number of recent states. In practice, clients keep various databases for different data categories. Each client can implement a different backend to handle this data, e.g. leveldb, pebble, mdbx.
 
@@ -310,25 +310,14 @@ Blockchain and state data processed by execution client need to be stored in the
 
 TODO
 
-## Pebble
+**Pebble**
 
-### Usage in the Execution Layer
+Pebble is used by some execution clients as a replacement for LevelDB, fulfilling the same role as the primary embedded key–value store for blockchain data, execution state, and indices. Geth have chosen pebble as an alternative and now default backend because LevelDB stopped being maintained. It provides same set of features with certain advantages as its development continues. 
 
-Pebble is used by some execution clients as a replacement for LevelDB, fulfilling the same role as the primary embedded key–value store for blockchain data, execution state, and indices. The Execution Layer’s data model, key namespaces, and atomicity boundaries remain unchanged; only the underlying storage engine differs.
 
-### Internals and advantages over LevelDB
-
-Pebble retains the LSM-tree architecture but improves it for write-heavy, latency-sensitive workloads typical of Ethereum execution. It supports multiple active memtables to reduce write stalls, exposes detailed SSTable and compaction metadata, and provides significantly more control over compaction behavior. These improvements allow clients to better manage write amplification and achieve more predictable performance under frequent state updates.
-
+Compared to LevelDB, Pebble retains the LSM-tree architecture but improves it for write-heavy, latency-sensitive workloads typical of Ethereum execution. It supports multiple active memtables to reduce write stalls, exposes detailed SSTable and compaction metadata, and provides significantly more control over compaction behavior. These improvements allow clients to better manage write amplification and achieve more predictable performance under frequent state updates. 
 Pebble also offers stronger batch semantics and snapshot support, enabling execution clients to better align database operations with block execution and concurrent RPC reads.
 
-### Relation to the Execution Layer Specification
-
-The Execution Layer Specification models storage as an abstract key–value database and does not prescribe a concrete backend. Pebble fits this abstraction directly, allowing clients to adopt it without changing execution semantics or protocol logic.
-
-### Reference
-
-Pebble documentation and design notes:  
 https://github.com/cockroachdb/pebble
 
 


### PR DESCRIPTION
This PR adds a concise documentation section describing Pebble as a storage
backend used by some Ethereum execution clients.

The section focuses on:
- Pebble’s role as a replacement for LevelDB in the Execution Layer
- The key advantages Pebble provides over LevelDB for execution workloads
- How Pebble fits the abstract storage model defined by the Execution Layer
  Specification

The intent is to provide clear, non-redundant context for readers progressing
from the LevelDB section, without introducing implementation-specific or
protocol-level assumptions.