### PR TITLE
docs: remove empty wordlist entry

### DIFF
--- a/wordlist.txt
+++ b/wordlist.txt
@@ -1,5 +1,4 @@
 personal_ws-1.1 en 10000 utf-8
-
 aantop
 ABI
 accelerometer


### PR DESCRIPTION
## Summary

- remove the empty line after the `wordlist.txt` personal dictionary header

## Context

`aspell` treats the blank line after the `personal_ws-1.1 ...` header as an empty string entry and fails with:

```text
The word "" is invalid. Empty string.
