### PR TITLE
Add automated Markdown link checker workflow

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,26 @@
+name: 'Check Markdown links'
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**.md'
+  pull_request:
+    paths:
+      - '**.md'
+  schedule:
+    - cron: '0 5 * * 2'
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Check links in changed files
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        config-file: '.github/workflows/mlc_config.json'
+        check-modified-files-only: 'yes'
+        file-extension: '.md'

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -23,4 +23,5 @@ jobs:
       with:
         config-file: '.github/workflows/mlc_config.json'
         check-modified-files-only: 'yes'
+        base-branch: 'main'
         file-extension: '.md'

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -2,7 +2,7 @@ name: 'Check Markdown links'
 
 on:
   push:
-    branches: [main, add-link-checker-workflow]
+    branches: [main]
     paths:
       - '**.md'
   pull_request:

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -2,7 +2,7 @@ name: 'Check Markdown links'
 
 on:
   push:
-    branches: [main]
+    branches: [main, add-link-checker-workflow]
     paths:
       - '**.md'
   pull_request:

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,0 +1,19 @@
+{
+  "retryCount": 3,
+  "retryDelay": 5,
+  "aliveStatusCodes": [200, 429],
+  "ignorePatterns": [
+    {
+      "pattern": "^https?://web.archive.org"
+    },
+    {
+      "pattern": "^https?://github.com/eth-protocol-fellows/protocol-studies/(issues|pulls)"
+    },
+    {
+      "pattern": "^https?://yewtu.be"
+    },
+    {
+      "pattern": "^https?://www.gnu.org"
+    }
+  ]
+}

--- a/test-link.md
+++ b/test-link.md
@@ -1,8 +1,0 @@
-# Link Checker Test
-
-This is a test file to verify the link checker workflow.
-
-- Valid link: [Ethereum.org](https://ethereum.org)
-- Broken link: [This link is broken](https://this-is-a-broken-link-12345.com)
-- Ignored link (web.archive.org): [Wayback Machine](https://web.archive.org/web/20210101000000/https://ethereum.org)
-- Rate limited link (handled): [GNU](https://www.gnu.org)

--- a/test-link.md
+++ b/test-link.md
@@ -1,0 +1,8 @@
+# Link Checker Test
+
+This is a test file to verify the link checker workflow.
+
+- Valid link: [Ethereum.org](https://ethereum.org)
+- Broken link: [This link is broken](https://this-is-a-broken-link-12345.com)
+- Ignored link (web.archive.org): [Wayback Machine](https://web.archive.org/web/20210101000000/https://ethereum.org)
+- Rate limited link (handled): [GNU](https://www.gnu.org)

--- a/test-link.md
+++ b/test-link.md
@@ -4,5 +4,5 @@ This is a test file to verify the link checker workflow.
 
 - Valid link: [Ethereum.org](https://ethereum.org)
 - Broken link: [This link is broken](https://this-is-a-broken-link-12345.com)
-- Ignored link (web.archive.org): [Wayback Machine](https://web.archive.org/web/20210101000000/https://ethereum.org)
+- Ignored link (web.archive.org): [Wayback M- Triggering workflow again.achine](https://web.archive.org/web/20210101000000/https://ethereum.org)
 - Rate limited link (handled): [GNU](https://www.gnu.org)


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automatically find broken links in Markdown files, as discussed in #295.

### What it does
- Runs when .md files are pushed to main or in a pull request – checks only changed files.
- A weekly scheduled job checks all files.
- Uses `markdown-link-check` with a custom config.

### Config highlights
- Retries failed links 3 times (handles temporary network issues).
- Accepts HTTP 429 as “alive” to avoid rate‑limit false alarms.
- Skips domains that often fail or rate‑limit: web.archive.org, yewtu.be, gnu.org, and GitHub issue/PR links.
- Tested on a feature branch – broken links are caught, ignored links are properly skipped.

Closes #295